### PR TITLE
Fix Global.getTable return type annotation to support nil

### DIFF
--- a/library/Global.lua
+++ b/library/Global.lua
@@ -240,7 +240,7 @@ function Global.getSnapPoints() end
 ---Get the reference to a table variable in the Global script.
 ---
 ---@param table_name string The name of the table to get.
----@return table
+---@return table?
 ---
 ---***
 ---


### PR DESCRIPTION
Tabletop Simulator starts out returning nil for global tables of a particular name until a valid table is set for that name. I updated the annotation to reflect this.