### PR TITLE
Remove $ from config.files

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_config.schema.json",
     "name": "TTSLua",
     "description": "Provides definitions for Tabletop Simulator's Lua API",
-    "files": ["Global%.%-1%.lua", ".+%.[a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9]%.lua$", "%.ttslua"],
+    "files": ["Global%.%-1%.lua", ".+%.[a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9]%.lua", "%.ttslua"],
     "settings": {
         "Lua.diagnostics.disable": ["lowercase-global"],
         "Lua.runtime.version": "Lua 5.2",


### PR DESCRIPTION
The $ in the "object.guid.lua$" breaks the pattern.  
I'm using [TTS Editor](https://github.com/Sebaestschjin/tts-tools/tree/main/packages/tts-editor) in which Global.lua doesn't have -1 in the middle of the name, so I'm relying on "object.guid" file pattern, but I just couldn't get the pop-up to trigger. Removing the $ finally fixed it.

My LuaLS logs shows an additional suffix on the pattern so I think that's why it doesn't work:
`[10:46:03.628][info] [#0:script\library.lua:586]: Found 3rd library by filename: 	([%w_]?).+%.[a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9][a-z0-9]%.lua([%w_]?)	file:///***/.tts/bundled/Custom_Token.7370f1.lua ...`